### PR TITLE
fix: use png logo in link png icon

### DIFF
--- a/website/src/root.tsx
+++ b/website/src/root.tsx
@@ -54,7 +54,7 @@ export const links: LinksFunction = () => [
     rel: "icon",
     type: "image/png",
     sizes: "32x32",
-    href: "/images/logo_svg.svg",
+    href: "/images/logo.png",
   },
   { rel: "manifest", href: "/manifest.webmanifest" },
   { rel: "icon", href: "/images/favicon.ico" },


### PR DESCRIPTION
Resolve warning

```
Warning: Encountered two children with the same key, `icon/images/logo_svg.svg`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```