### PR TITLE
style: use grid auto fill to display icons

### DIFF
--- a/website/src/components/grid/index.tsx
+++ b/website/src/components/grid/index.tsx
@@ -6,9 +6,7 @@ interface GridProps {
 
 const Grid = (props: GridProps) => {
   return (
-    <div className="mx-auto mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-6">
-      {props.children}
-    </div>
+    <div className="grid-cols-fill mx-auto grid gap-4">{props.children}</div>
   )
 }
 

--- a/website/tailwind.config.ts
+++ b/website/tailwind.config.ts
@@ -8,6 +8,9 @@ export default {
         sans: ["General-Sans", "sans-serif"],
         mono: ["Hack", "monospace"],
       },
+      gridTemplateColumns: {
+        fill: "repeat(auto-fill, minmax(13rem, 1fr))",
+      },
     },
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
At large sizes, the 6 columns are kept at the maximum size.
At small sizes, 2 columns are displayed

### Before
![Before](https://github.com/pheralb/react-symbols/assets/32694631/b38f4b10-2fcf-4818-9988-c9090af3ca35)


### After
![image](https://github.com/pheralb/react-symbols/assets/32694631/04e437e2-c094-4ac4-b477-b4afe7680663)
