### PR TITLE
fix: change isFolder with true

### DIFF
--- a/website/app/routes/folders._index.tsx
+++ b/website/app/routes/folders._index.tsx
@@ -42,7 +42,7 @@ export default function Folders() {
             return (
               <Card
                 key={icon.name}
-                isFolder={false}
+                isFolder={true}
                 iconSize={deferredSize}
                 {...icon}
               />


### PR DESCRIPTION
### Descripción
Los enlaces para los iconos de carpetas van a un 404

## Cambios realizados
- [x] Se cambió el valor de `isFolder` en la página de `/folders`